### PR TITLE
完善中国专利案件状态对照表：补全 120–999 状态代码并规范英文说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,102 @@
 # 中国专利案件状态汇总 / China Patent Statuses
 
-| 案件状态代码 | 案件状态                   | Filing Status                                                                    |
-| ------------ | -------------------------- | -------------------------------------------------------------------------------- |
-| 120          | 案件接收管理               |                                                                                  |
-| 121          | 等待电子文件入库           |                                                                                  |
-| 124          | 待发受理通知书             |                                                                                  |
-| 125          | 等待申请费                 |                                                                                  |
-| 126          | 未缴申请费视撤，等恢复     |                                                                                  |
-| 127          | 无申请费视撤失效           |                                                                                  |
-| 128          | 等待申请费收据             |                                                                                  |
-| 130          | 受理审查                   |                                                                                  |
-| 138          | 撤回专利申请               |                                                                                  |
-| 140          | 准备进入分类               |                                                                                  |
-| 144          | 等待代码化文件             |                                                                                  |
-| 145          | 等待装库                   |                                                                                  |
-| 150          | 待计算机辅助分类           |                                                                                  |
-| 152          | 分类待提取                 |                                                                                  |
-| 162          | 审查待提取                 |                                                                                  |
-| 166          | 形式审查                   |                                                                                  |
-| 170          | 准备进入发明初审           |                                                                                  |
-| 171          | 准备进入新型初审           |                                                                                  |
-| 173          | 保密挑选                   |                                                                                  |
-| 174          | 案件粗分                   |                                                                                  |
-| 175          | 等待案件分配               |                                                                                  |
-| 177          | 等待提案                   |                                                                                  |
-| 180          | 新案审查                   |                                                                                  |
-| 181          | 细分审查                   |                                                                                  |
-| 183          | 案件质检                   |                                                                                  |
-| 185          | 初审待答复                 |                                                                                  |
-| 190          | 回案审查                   |                                                                                  |
-| 195          | 准备等待公布               |                                                                                  |
-| 201          | 等待公布                   |                                                                                  |
-| 202          | 准备公布                   |                                                                                  |
-| 203          | 公布封卷                   |                                                                                  |
-| 210          | 国优视撤                   | Domestic priority deemed to be withdrawal                                        |
-| 220          | 等待实审请求               | Waiting for request for substantive examination                                  |
-| 225          | 实审请求视撤，等恢复       |                                                                                  |
-| 229          | 实审请求视撤失效           |                                                                                  |
-| 300          | 准备进入实审阶段           |                                                                                  |
-| 301          | 等待实审提案               | Waiting for selection of substantive examination                                 |
-| 310          | 进入实审                   | Entering the substantive examination                                             |
-| 311          | 进入审查                   |                                                                                  |
-| 360          | 一通出案待答复             | Sending out the first office action, waiting for reply                           |
-| 365          | 回案形审                   |                                                                                  |
-| 370          | 一通回案实审               | Returned case after the first office action for substantive examination          |
-| 380          | 中通出案待答复             |                                                                                  |
-| 390          | 中通回案实审               | Returned case after Nth office action for substantive examination                |
-| 400          | 逾期视撤，等恢复           | Deemed to be withdrawn due to overdue, Waiting for restoration                   |
-| 410          | 逾期视撤失效               | Deemed to be withdrawn due to overdue, Invalidation                              |
-| 500          | 待质检抽案                 |                                                                                  |
-| 520          | 实审检查                   |                                                                                  |
-| 600          | 驳回等复审请求             | Rejection, Waiting for request for reexamination                                 |
-| 601          | 等待扫描代码化             |                                                                                  |
-| 602          | 收到复审请求               |                                                                                  |
-| 604          | 等待形式审查分配           |                                                                                  |
-| 605          | 等待前置审查发送           |                                                                                  |
-| 606          | 等待前置审查返回           |                                                                                  |
-| 620          | 等待合议组成立             |                                                                                  |
-| 630          | 合议组审查                 | Panel examination                                                                |
-| 631          | 复审程序中                 |                                                                                  |
-| 634          | 复审质检                   |                                                                                  |
-| 640          | 等待发决定书               |                                                                                  |
-| 641          | 等待诉讼                   | Waiting for appeal                                                               |
-| 750          | 驳回失效                   | Invalidation of rejection                                                        |
-| 790          | 待发授权办登通知书         |                                                                                  |
-| 800          | 等年登印费                 | Waiting for annual registration fee                                              |
-| 810          | 视为放弃，等恢复           |                                                                                  |
-| 820          | 视为放弃失效               |                                                                                  |
-| 830          | 等年登印费收据             | Waiting for annual registration fee receipt                                      |
-| 860          | 等待颁证公告               |                                                                                  |
-| 865          | 待公告                     |                                                                                  |
-| 870          | 准备颁证公告               |                                                                                  |
-| 880          | 公告封卷                   | Announcement and seal of case                                                    |
-| 900          | 专利权维持                 | Patent right maintenance                                                         |
-| 910          | 等年费滞纳金               | Waiting for surcharge of annual fee                                              |
-| 920          | 未缴年费专利权终止，等恢复 | Patent right lapse due to failing to pay the annual fee, Waiting for restoration |
-| 930          | 未缴年费终止失效           | Lapse due to non-Payment of annual fee                                           |
-| 970          | 放弃专利权（主动放弃）     |                                                                                  |
-| 971          | 放弃专利权（重复授权）     |                                                                                  |
-| 972          | 放弃专利权（同样发明创造） |                                                                                  |
-| 997          | 届满终止，待失效           |                                                                                  |
-| 998          | 届满终止失效               | Invalidation of suspension due to expiration of time limit                       |
-| 999          | 无效宣告失效               |                                                                                  |
+| 排序码 | 案件状态                     | Filling Status                                                                   | 备注                                                                       |
+| ------ | ---------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 120    | 案件接收管理                 |                                                                                  |
+| 121    | 等待电子文件入库             |
+| 124    | 待发受理通知书               |
+| 125    | 等待申请费                   |
+| 126    | 未缴申请费视撤，等恢复       |
+| 127    | 无申请费视撤失效             |
+| 128    | 等待申请费收据               |                                                                                  | 自定义状态                                                                 |
+| 130    | 受理审查                     |
+| 138    | 撤回专利申请                 |
+| 140    | 准备进入分类                 |
+| 144    | 等待代码化文件               |
+| 145    | 等待装库                     |
+| 150    | 待计算机辅助分类             |
+| 152    | 分类待提取                   |
+| 162    | 审查待提取                   |
+| 166    | 形式审查                     |
+| 170    | 准备进入发明初审             |
+| 171    | 准备进入新型初审             |
+| 173    | 保密挑选                     |
+| 174    | 案件粗分                     |
+| 175    | 等待案件分配                 |
+| 177    | 等待提案                     |
+| 180    | 新案审查                     |
+| 181    | 细分审查                     |
+| 183    | 案件质检                     |
+| 185    | 初审待答复                   |
+| 190    | 回案审查                     |
+| 195    | 准备等待公布                 |
+| 201    | 等待公布                     |
+| 202    | 准备公布                     |
+| 203    | 公布封卷                     |
+| 210    | 国优视撤                     | Domestic priority deemed to be withdrawal                                        |
+| 220    | 等待实审请求                 | Waiting for request for substantive examination                                  |
+| 225    | 实审请求视撤，等恢复         |
+| 229    | 实审请求视撤失效             |
+| 300    | 准备进入实审阶段             |
+| 301    | 等待实审提案                 | Waiting for selection of substantive examination                                 |
+| 310    | 进入实审                     | Entering the substantive examination                                             |
+| 311    | 进入审查                     |
+| 360    | 一通出案待答复               | Sending out the first office action, waiting for reply                           |
+| 361    | 一通答审意见撰写中           |                                                                                  | 自定义状态                                                                 |
+| 362    | 等发明人确认一通答审意见     |                                                                                  | 自定义状态                                                                 |
+| 363    | 等IPR确认一通答审意见        |                                                                                  | 自定义状态                                                                 |
+| 364    | 等一通答审意见回执           |                                                                                  | 自定义状态                                                                 |
+| 365    | 回案形审                     |
+| 370    | 一通回案实审                 | Returned case after the first office action for substantive examination          |
+| 380    | 中通出案待答复               |
+| 381    | 中通答审意见撰写中           |                                                                                  | 自定义状态                                                                 |
+| 382    | 等发明人确认中通答审意见     |                                                                                  | 自定义状态                                                                 |
+| 383    | 等IPR确认中通答审意见        |                                                                                  | 自定义状态                                                                 |
+| 384    | 等中通答审意见回执           |                                                                                  | 自定义状态                                                                 |
+| 390    | 中通回案实审                 | Returned case after Nth office action for substantive examination                |
+| 400    | 逾期视撤，等恢复             | Deemed to be withdrawn due to overdue, Waiting for restoration                   |
+| 410    | 逾期视撤失效                 | Deemed to be withdrawn due to overdue, Invalidation                              |
+| 500    | 待质检抽案                   |
+| 520    | 实审检查                     |
+| 600    | 驳回等复审请求               | Rejection, Waiting for request for reexamination                                 |
+| 601    | 复审请求意见撰写中           |                                                                                  | 自定义状态                                                                 |
+| 602    | 等发明人确认复审请求意见     |                                                                                  | 自定义状态                                                                 |
+| 603    | 等IPR确认复审请求意见        |                                                                                  | 自定义状态                                                                 |
+| 604    | 等复审请求回执               |                                                                                  | 自定义状态                                                                 |
+| 611    | 等待扫描代码化               |
+| 612    | 收到复审请求                 |
+| 614    | 等待形式审查分配             |
+| 615    | 等待前置审查发送             |
+| 616    | 等待前置审查返回             |
+| 620    | 等待合议组成立               |
+| 625    | 合议组审查                   | Panel examination                                                                |
+| 629    | 复审程序中                   |
+| 630    | 复通出案待答复               |                                                                                  | 自定义状态                                                                 |
+| 631    | 复通答审意见撰写中           |                                                                                  | 自定义状态                                                                 |
+| 632    | 等发明人确认复通答审意见     |                                                                                  | 自定义状态                                                                 |
+| 633    | 等IPR确认复通答审意见        |                                                                                  | 自定义状态                                                                 |
+| 634    | 等复通答审意见回执           |                                                                                  | 自定义状态                                                                 |
+| 635    | 复通回案审查                 |
+| 639    | 复审质检                     |
+| 640    | 等待发决定书                 |
+| 641    | 复审维持驳回决定，等行政诉讼 | Waiting for appeal                                                               |
+| 750    | 驳回失效                     | Invalidation of rejection                                                        |
+| 790    | 待发授权办登通知书           |
+| 800    | 等年登印费                   | Waiting for annual registration fee                                              |
+| 810    | 视为放弃，等恢复             |
+| 820    | 视为放弃失效                 |
+| 830    | 等年登印费收据               |                                                                                  | 自定义状态                                                                 |
+| 860    | 等待颁证公告                 |
+| 865    | 待公告                       |
+| 870    | 准备颁证公告                 |
+| 880    | 公告封卷                     | Announcement and seal of case                                                    |
+| 900    | 专利权维持                   | Patent right maintenance                                                         |
+| 910    | 等年费滞纳金                 | Waiting for surcharge of annual fee                                              |
+| 920    | 未缴年费专利权终止，等恢复   | Patent right lapse due to failing to pay the annual fee, Waiting for restoration |
+| 930    | 未缴年费终止失效             | Lapse due to non-Payment of annual fee                                           |
+| 970    | 放弃专利权（主动放弃）       |
+| 971    | 放弃专利权（重复授权）       |
+| 972    | 放弃专利权（同样发明创造）   |
+| 997    | 届满终止，待失效             |
+| 998    | 届满终止失效                 | Invalidation of suspension due to expiration of time limit                       |
+| 999    | 无效宣告失效                 |                                                                                  | 届满终止失效后仍然有可能被无效，但是被无效宣告后绝不可能再出现届满终止失效 |


### PR DESCRIPTION
一、背景与问题
现有 README 中的案件状态代码列表不完整，仅覆盖部分流程节点，难以作为完整对照表使用。
表格结构存在问题：部分英文说明被拆成多行，列数不一致，Markdown 渲染效果和复制/程序化解析都会出错。
内部自定义流程状态与官方状态混在一起，缺少明确标记，不利于使用方区分。
二、本次变更内容
补全中国专利案件从 120 到 999 的状态代码，并为主要状态补充/规范英文状态说明，使之形成较完整的中英对照表。
新增“备注”列，用于标记内部自定义流程状态（如“一通/中通/复通答审意见撰写中、等待确认、等待回执”等），避免与官方状态混淆。
统一排序码格式为三位数字，规整 Markdown 表头和列数，解决原表中英文说明被拆行、列不对齐等结构性问题。
三、预期效果
使 README 中的案件状态表可以作为相对完整、可查阅的中国专利案件状态对照表使用。
提高表格在复制、导出或被脚本直接解析时的可靠性，方便下游工具和流程集成。